### PR TITLE
instruction on how to use dom-abc

### DIFF
--- a/test/test_subcellprofile/test_module_subcellprofile_domlfq_protein_dia_expl.py
+++ b/test/test_subcellprofile/test_module_subcellprofile_domlfq_protein_dia_expl.py
@@ -37,6 +37,7 @@ def load_file(format_name: str):
 
 class TestOutputFileReading:
     """Simple tests for reading csv input files."""
+
     def test_if_module_supports_search_tool(self):
         """Test whether all software tools supported by the module are actually tested."""
         parse_settings = ParseSettingsBuilder(

--- a/test/test_subcellprofile/test_module_subcellprofile_domlfq_protein_dia_expl.py
+++ b/test/test_subcellprofile/test_module_subcellprofile_domlfq_protein_dia_expl.py
@@ -37,7 +37,6 @@ def load_file(format_name: str):
 
 class TestOutputFileReading:
     """Simple tests for reading csv input files."""
-
     def test_if_module_supports_search_tool(self):
         """Test whether all software tools supported by the module are actually tested."""
         parse_settings = ParseSettingsBuilder(

--- a/webinterface/pages/markdown_files/subcellprofile/domlfq/protein/DIA/EXPL/how_to_move_to_domabc.md
+++ b/webinterface/pages/markdown_files/subcellprofile/domlfq/protein/DIA/EXPL/how_to_move_to_domabc.md
@@ -1,0 +1,14 @@
+You can download here the results of this analysis and visualise them more in depth in the [DOM-ABC web application](https://domqc.bornerlab.org/NMCComp). You can then explore more in depth your analysis results, as presented in [Schessner et al. (Nature Communications, 2023)](https://www.nature.com/articles/s41467-023-41000-7).
+
+The domaps analysis is already performed so you can directly go to the `Benchmark` tab. 
+
+1. Click on `Choose file` and select the .json from ProteoBench
+2. Check the box corresponding to your data point
+3. Press `Align and analyse selected datasets` 
+
+You can then explore your data more in depth, and visualise the results for each cluster independently (in the `intramap scatter` tab).
+
+
+
+
+


### PR DESCRIPTION
I created a markdown document that should be used in the web interface for the tab "Results in depth". 
I am not sure that all the functionalities of the spacial QC tool are available with a single .json generated by ProteoBench. We will need to check that. 
For example, I have errors using the "SVN analysis" and "Profile comparison" tabs. 